### PR TITLE
Update ServiceAccount Role Binding for OCP 4.12

### DIFF
--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: Grant the grafana service account the cluster-monitoring-view
-  command: "oc adm policy add-cluster-role-to-user cluster-monitoring-view -z {{ grafana_service_account }}"
+- name: Grant the grafana service account the prometheus-k8s
+  command: "oc adm policy add-cluster-role-to-user prometheus-k8s -z {{ grafana_service_account }}"
 
 - name: Determine the grafana service account's token name
   command: "oc -n {{ grafana_namespace }} get sa {{ grafana_service_account }} -o jsonpath='{.secrets[0].name}'"

--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: Grant the grafana service account the prometheus-k8s
-  command: "oc -n {{ grafana_namespace }} adm policy add-cluster-role-to-user prometheus-k8s -z {{ grafana_service_account }}"
+- name: Grant the grafana service account the thanos-querier
+  command: "oc -n {{ grafana_namespace }} adm policy add-cluster-role-to-user thanos-querier -z {{ grafana_service_account }}"
 
 - name: Determine the grafana service account's token name
-  command: "oc -n {{ grafana_namespace }} get sa {{ grafana_service_account }} -o jsonpath='{.secrets[0].name}'"
+  shell: "oc -n {{ grafana_namespace }} get secrets | grep {{ grafana_service_account }}-token | awk '{print $1}'"
   register: secret_name
 
 - name: Fetch the token

--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: Grant the grafana service account the thanos-querier
-  command: "oc -n {{ grafana_namespace }} adm policy add-cluster-role-to-user thanos-querier -z {{ grafana_service_account }}"
+- name: Grant the grafana service account the cluster-monitoring-view
+  command: "oc -n {{ grafana_namespace }} adm policy add-cluster-role-to-user cluster-monitoring-view -z {{ grafana_service_account }}"
 
 - name: Determine the grafana service account's token name
   shell: "oc -n {{ grafana_namespace }} get secrets | grep {{ grafana_service_account }}-token | awk '{print $1}'"


### PR DESCRIPTION
This PR updates the way the service account token secret is found, since OCP 4.12 removed tokens from a serviceaccount's JSON.

This closes #12 