### PR TITLE
datasource: Fix auth issue in datasource

### DIFF
--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Grant the grafana service account the cluster-monitoring-view
-  command: "oc adm policy add-cluster-role-to-user cluster-monitoring-view -z {{ grafana_service_account }}"
+  command: "oc -n {{ grafana_namespace }} adm policy add-cluster-role-to-user cluster-monitoring-view -z {{ grafana_service_account }}"
 
 - name: Determine the grafana service account's token name
   command: "oc -n {{ grafana_namespace }} get sa {{ grafana_service_account }} -o jsonpath='{.secrets[0].name}'"
   register: secret_name
 
 - name: Fetch the token
-  command: "oc -n {{ grafana_namespace }} get secret {{ secret_name.stdout }} -o jsonpath='{.metadata.annotations.openshift\\.io/token-secret\\.value}'"
+  shell: "oc -n {{ grafana_namespace }} get secret {{ secret_name.stdout }} -o jsonpath='{.data.token}' | base64 -d"
   register: sa_secret
 
 - name: Set the token from Service Account secret

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,5 +1,5 @@
 grafana_user: grafana
-grafana_image_tag: 9.3.1
+grafana_image_tag: 9.1.7
 grafana_cpu_requests: 500m
 grafana_mem_requests: 1Gi
 


### PR DESCRIPTION
Under Grafana 9.3, auth issues were hidden under HTTP 500. This patch regresses the grafana image to 9.1.7 and changes the location of the token and how it is extracted/decoded.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>