### PR TITLE
switch to default namespace before deletion of grafana namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ OR
 # ansible-playbook purge-local.yml
 ```
 
-NB. When you're removing you OpenShift based deployment, remember to use `oc project default` to ensure you're not in the odf-grafana namesspace.
-
 ### Adding a dashboard
 
 If you need to add dashboards to your instance after a deployment, you can use the `add-dashboard.yml` playbook and specify the path to the dashboard file either from the all.yml file or as an extra-vars on the playbook command line.

--- a/purge-grafana.yml
+++ b/purge-grafana.yml
@@ -30,6 +30,11 @@
         msg: Aborted the namespace delete
       when: confirm.user_input.upper() != 'YES'
     
+    - name: Switch to default namespace before deleting '{{ grafana_namespace }}'
+      command:
+        cmd: oc project default
+      when: confirm.user_input.upper() == 'YES'
+    
     - name: Deleting the namespace
       command:
         cmd: oc delete ns {{ grafana_namespace }}


### PR DESCRIPTION
Ensure we are in `default` namespace before 
```
oc delete ns {{ grafana_namespace }}
``` 
is executed. 

