### PR TITLE
Ocp4.16 fix

### DIFF
--- a/roles/dashboard/templates/dashboard.j2
+++ b/roles/dashboard/templates/dashboard.j2
@@ -1,4 +1,4 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: {{ dashboard_name }}
@@ -6,7 +6,10 @@ metadata:
     app: grafana
   namespace: {{ grafana_namespace }}
 spec:
-  customFolderName: PerfScale
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana-dashboard"
+  folder: PerfScale
   json: >
 {% for line in dashboard_content[1:-1].split('\n') %}
     {{ line }}

--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -29,6 +29,15 @@
     - sa_secret_method_2.stdout
     - not sa_secret_method_1.stdout
 
+    #- name: create token for OCP4.16
+    #  shell: "oc -n {{ grafana_namespace }} create token {{ grafana_service_account }}"
+    #  register: new_token
+    #  set_fact:
+    #    token: "{{ new_token.stdout }}"
+    #  when:
+    #    - secret_name.rc == 0
+    #    - new_token.stdout
+
 - name: Show token
   debug:
     msg: "{{ token }}"

--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -14,8 +14,8 @@
   shell: "oc -n {{ grafana_namespace }} get secret {{ secret_name.stdout }} -o jsonpath='{.metadata.annotations.openshift\\.io/token-secret\\.value}'"
   register: sa_secret_method_2
 
-- name: create token for OCP4.16
-  shell: "oc -n {{ grafana_namespace }} create token {{ grafana_service_account }}"
+- name: create token for OCP4.16 for 60 days - method 3
+  shell: "oc -n {{ grafana_namespace }} create token {{ grafana_service_account }} --duration=$((60*24))h"
   register: sa_token
 
 - name: Set the token from Service Account secret from method 1

--- a/roles/datasource/tasks/main.yml
+++ b/roles/datasource/tasks/main.yml
@@ -14,6 +14,10 @@
   shell: "oc -n {{ grafana_namespace }} get secret {{ secret_name.stdout }} -o jsonpath='{.metadata.annotations.openshift\\.io/token-secret\\.value}'"
   register: sa_secret_method_2
 
+- name: create token for OCP4.16
+  shell: "oc -n {{ grafana_namespace }} create token {{ grafana_service_account }}"
+  register: sa_token
+
 - name: Set the token from Service Account secret from method 1
   set_fact:
     token: "{{ sa_secret_method_1.stdout }}"
@@ -29,14 +33,13 @@
     - sa_secret_method_2.stdout
     - not sa_secret_method_1.stdout
 
-    #- name: create token for OCP4.16
-    #  shell: "oc -n {{ grafana_namespace }} create token {{ grafana_service_account }}"
-    #  register: new_token
-    #  set_fact:
-    #    token: "{{ new_token.stdout }}"
-    #  when:
-    #    - secret_name.rc == 0
-    #    - new_token.stdout
+- name: set token for OCP4.16
+  set_fact:
+    token: "{{ sa_token.stdout }}"
+  when:
+    - secret_name.rc == 0
+    - sa_token.stdout
+    - not sa_secret_method_2.stdout
 
 - name: Show token
   debug:

--- a/roles/datasource/templates/infinity_datasource.j2
+++ b/roles/datasource/templates/infinity_datasource.j2
@@ -1,16 +1,19 @@
 ---
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDataSource
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
 metadata:
   name: infinity
   namespace: {{ grafana_namespace }}
 spec:
   name: {{ infinity_datasource_name}}.yml
-  datasources:
-    - name: {{ infinity_datasource_name }}
-      type: yesoreyeram-infinity-datasource
-      isDefault: false
-      version: 1
-      editable: true
-      jsonData:
-        tlsSkipVerify: true
+  datasource:
+    name: {{ infinity_datasource_name }}
+    type: yesoreyeram-infinity-datasource
+    isDefault: false
+    version: 1
+    editable: true
+    jsonData:
+      tlsSkipVerify: true
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana-dashboard"

--- a/roles/datasource/templates/prometheus_datasource.j2
+++ b/roles/datasource/templates/prometheus_datasource.j2
@@ -1,26 +1,27 @@
 ---
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDataSource
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
 metadata:
   name: prometheus
   namespace: {{ grafana_namespace }}
 spec:
   name: {{ prometheus_datasource_name }}.yml
-  datasources:
-    - name: {{ prometheus_datasource_name }}
-      type: prometheus
-      access: server
-      url: {{ prometheus_route }}
-      isDefault: true
-      version: 1
-      editable: true
-      jsonData:
-        tlsSkipVerify: true
-        timeInterval: "10s"
-        httpHeaderName1: 'HeaderName'
-        httpHeaderName2: 'Authorization'
-      secureJsonData:
-        httpHeaderValue1: 'HeaderValue'
-        httpHeaderValue2: 'Bearer {{ token }}'
+  datasource:
+    name: {{ prometheus_datasource_name }}
+    type: prometheus
+    access: proxy
+    url: {{ prometheus_route }}
+    isDefault: true
+    version: 1
+    editable: true
+    jsonData:
+      tlsSkipVerify: true
+      timeInterval: "10s"
+      httpHeaderName1: 'Authorization'
+    secureJsonData:
+      httpHeaderValue1: 'Bearer {{ token }}'
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana-dashboard"
 
 

--- a/roles/datasource/vars/main.yml
+++ b/roles/datasource/vars/main.yml
@@ -1,2 +1,3 @@
 prometheus_service_account: prometheus-k8s
-grafana_service_account: grafana-serviceaccount
+grafana_service_account: grafana-sa
+#grafana_service_account: grafana-serviceaccount

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,5 +1,6 @@
 grafana_user: grafana
-grafana_image_tag: 9.1.7
+#grafana_image_tag: 9.1.7
+grafana_image_tag: 11.1.0
 grafana_cpu_requests: 500m
 grafana_mem_requests: 1Gi
 

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for up to 10m for the Grafana operator to be available
   command:
-    cmd: oc -n {{ grafana_namespace }} get pod --selector=control-plane=controller-manager -o jsonpath='{.items[0].status.phase}'
+    cmd: oc -n {{ grafana_namespace }} get pod --selector=app.kubernetes.io/name=grafana-operator -o jsonpath='{.items[0].status.phase}'
   register: pod_state
   until: pod_state.stdout == "Running"
   retries: 120

--- a/roles/grafana/templates/grafana.j2
+++ b/roles/grafana/templates/grafana.j2
@@ -7,34 +7,37 @@ metadata:
 data:
   GF_INSTALL_PLUGINS: yesoreyeram-infinity-datasource
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   name: grafana
   namespace: {{ grafana_namespace }}
+  labels:
+    dashboards: "grafana-dashboard"
 spec:
-  baseImage: docker.io/grafana/grafana:{{ grafana_image_tag }}
+  version: {{ grafana_image_tag }}
   deployment:
     envFrom:
       - configMapRef:
           name: grafana-plugins
   client:
-    preferService: true
-  ingress:
-    enabled: True
-    pathType: Prefix
-    path: "/"
+    preferIngress: true
+  route:
+    spec:
+      enabled: "True"
+      pathType: Prefix
+      path: "/"
   config:
     log:
       mode: "console"
       level: "error"
     log.frontend:
-      enabled: true
+      enabled: "true"
     auth:
-      disable_login_form: False
-      disable_signout_menu: True
+      disable_login_form: "False"
+      disable_signout_menu: "True"
     auth.anonymous:
-      enabled: False
+      enabled: "False"
     security:
       admin_user: {{ grafana_user }}
       admin_password: {{ grafana_password }}

--- a/roles/operator/vars/main.yml
+++ b/roles/operator/vars/main.yml
@@ -1,2 +1,2 @@
-grafana_operator_channel: v4
-grafana_csv: grafana-operator.v4.5.1
+grafana_operator_channel: v5
+grafana_csv: grafana-operator.v5.9.2


### PR DESCRIPTION
## What?
I have fixed the issue of odf-grafana not working in OCP-4.16.

## How?
The latest grafana operator now supports OCP-4.16 but it needs to use grafana channel v5 (current code uses v4).
With grafan channel v5, there have been some major changes how grafana code works and those modifications have been incorporated in the code.

## Testing?
The code has been tested using OCP versions 4.16.0 and 4.15.17.
